### PR TITLE
Adding a TransportCapacityCalculator class

### DIFF
--- a/transport_capacity_computation.py
+++ b/transport_capacity_computation.py
@@ -17,251 +17,406 @@ from constants import (
     R_VAR,
 )
 
-def Parker_Klingeman_formula(fi_r_reach, D50, slope, wac, h, psi, **kwargs):
-    """
-    Returns the value of the transport capacity [Kg/s] for each sediment class
-    in the reach measured using the Parker and Klingeman equations.
-    This function is for use in the D-CASCADE toolbox.
-    CHECK THE UNIT OF THE RETURNED VARIABLE.
-    
-    References:
-    Parker and Klingeman (1982). On why gravel bed streams are paved. Water Resources Research.
-    """
-    
-    if 'gamma' not in kwargs: # if gamma was not given as input
-        gamma = 0.05 # hiding factor
-    
-    dmi = 2**(-psi) / 1000 # sediment classes diameter [m]
-    
-    ## Transport capacity from Parker and Klingema equations
-    
-    tau = RHO_W * GRAV * h * slope # bed shear stress [Kg m-1 s-1]
-    
-    # tau_r50 formula from Mueller et al. (2005)
-    # reference shear stress for the mean size of the bed surface sediment [Kg m-1 s-1]
-    tau_r50 = (0.021 + 2.18 * slope) * (RHO_W * R_VAR * GRAV * D50)
-    
-    tau_ri = tau_r50 * (dmi/D50)** gamma # reference shear stress for each sediment class [Kg m-1 s-1]
-    phi_ri = tau / tau_ri
-    
-    # Dimensionless transport rate for each sediment class [-]
-    w_i = 11.2 * (np.maximum(1 - 0.853/phi_ri, 0))**4.5
-    
-    # Dimensionful transport rate for each sediment class [m3/s]
-    tr_cap = wac * w_i * fi_r_reach * (tau / RHO_W)**(3/2) / (R_VAR * GRAV)
-    tr_cap[np.isnan(tr_cap)] = 0 #if Qbi_tr are NaN, they are put to 0
-    
-    return tr_cap, tau, tau_r50
-    
-def Wilcock_Crowe_formula(fi_r_reach, D50, slope, wac, h, psi): 
-    """
-    Returns the value of the transport capacity [m3/s] for each sediment class
-    in the reach measured using the Wilcock and Crowe equations.
-    This function is for use in the D-CASCADE toolbox.
-    
-    References:
-    Wilcock, Crowe(2003). Surface-based transport model for mixed-size sediment. Journal of Hydraulic Engineering.
-    """
+class TransportCapacityCalculator:
+    def __init__(self, Fi_r_reach, D50, slope, Q, wac, v, h, psi, gamma=0.05):
+        # Dictionary mapping indices to different formula
+        self.index_to_formula = {
+            1: self.Parker_Klingeman_formula,
+            2: self.Wilcock_Crowe_formula,
+            3: self.Engelund_Hansen_formula,
+            4: self.Yang_formula,
+            5: self.Wong_Parker_formula,
+            6: self.Ackers_White_formula,
+            7: self.Rickenmann_formula
+        }
+        self.Fi_r_reach = Fi_r_reach
+        self.D50 = D50
+        self.slope = slope
+        self.Q = Q
+        self.wac = wac
+        self.v = v
+        self.h = h
+        self.psi = psi
 
-    dmi = 2**(-psi) / 1000 # sediment classes diameter [m]
-    
-    if fi_r_reach.ndim == 1:
-        fi_r_reach = fi_r_reach[:,None]
-        # Fraction of sand in river bed (sand considered as sediment with phi > -1)
-        Fr_s = np.sum((psi > - 1)[:,None] * 1 * fi_r_reach)
-    else:
-        Fr_s = np.sum((psi > - 1)[:,None] * 1 * fi_r_reach, axis = 0)[None,:]
-    ## Transport capacity from Wilcock-Crowe equations
+    # def execute(self, index, *args, **kwargs):
+    #     """
+    #     Chooses the transport capacity function based on the given index.
+    #     """
+    #     # EB D50 entries change according to formula index - it would be good to create a class 
+    #     # to call with the string name of the formula
+    #
+    #     # Execute the formula corresponding to the given index
+    #     if index in self.index_to_formula:
+    #         return self.index_to_formula[index](*args, **kwargs)
+    #     else:
+    #         print("Invalid index.")
+    #         return None
+        
+    def choose_formula(self, indx_tr_cap):
+        """
+        Dynamically chooses and calls the transport capacity function based on indx_tr_cap.
+        """
 
-    tau = np.array(RHO_W * GRAV * h * slope) # bed shear stress [Kg m-1 s-1]
-    if tau.ndim != 0:
-        tau = tau[None,:] # add a dimension for computation
-    
-    # reference shear stress for the mean size of the bed surface sediment [Kg m-1 s-1]
-    tau_r50 = (0.021 + 0.015 * np.exp(-20 * Fr_s)) * (RHO_W * R_VAR * GRAV * D50)
-    
-    b = 0.67 / (1 + np.exp(1.5 - dmi / D50)) # hiding factor
-    
-    fact = (dmi / D50)**b
-    tau_ri = tau_r50 * fact[:,None] # reference shear stress for each sediment class [Kg m-1 s-1]
-    
-    phi_ri = tau / tau_ri
-    # Dimensionless transport rate for each sediment class [-]
-    # The formula changes for each class according to the phi_ri of the class
-    # is higher or lower then 1.35.
-    W_i = (phi_ri >= 1.35) * (14 * (np.maximum(1 - 0.894 / np.sqrt(phi_ri), 0))**4.5) + (phi_ri < 1.35) * (0.002 * phi_ri**7.5)
-    
-    # Dimensionful transport rate for each sediment class [m3/s]
-    if wac.ndim == 0:
-        tr_cap = wac * W_i * fi_r_reach * (tau / RHO_W)**(3/2) / (R_VAR * GRAV)
-        if tr_cap.ndim > 1:
-           tr_cap = np.squeeze(tr_cap) # EB: a bit of a mess here with dimensions, corrected a posteriori. I want a 1-d vector as output 
-    else:
-        wac = np.array(wac)[None, :]
-        tr_cap = wac * W_i * fi_r_reach * (tau / RHO_W)**(3/2) / (R_VAR * GRAV)
-    
-    tr_cap[np.isnan(tr_cap)] = 0 #if Qbi_tr are NaN, they are put to 0
+        # Look up the function using the index in the dictionary
+        formula = self.index_to_formula.get(indx_tr_cap)
 
-    return tr_cap, tau, tau_r50
+        if formula is None:
+            raise ValueError(f"No formula associated with index {indx_tr_cap}")
 
-def Engelund_Hansen_formula(D50, slope, wac, v, h):
-    """
-    Returns the value of the transport capacity [m3/s] for each sediment class
-    in the reach measured using the Engelund and Hansen equations.
-    This function is for use in the D-CASCADE toolbox.
-    
-    WARNING: Engelund and Hansen use a factor of 0.1 and but this function uses
-    a factor of 0.05.
-    
-    slope: All reaches' slopes
-    h: All reaches' water heights
-    
-    References:
-    Engelund, F., and E. Hansen (1967), A Monograph on Sediment Transport in 
-    Alluvial Streams, Tekniskforlag, Copenhagen.
-    """
-    
-    # Friction factor (Eq. 3.1.3 of the monograph)
-    C = (2 * GRAV * slope * h) / v**2
+        result = formula()
 
-    # Dimensionless shear stress (Eq. 3.2.3)
-    tau_eh = (slope * h) / (R_VAR * D50)
-    # Dimensionless transport capacity (Eq. 4.3.5), although Engelund and Hansen
-    # find a factor of 0.1 and not 0.05.
-    q_eh = 0.05 / C * tau_eh**(5/2)
-    # Dimensionful transport capacity per unit width [m3/(s*m)]
-    # (page 56 of the monograph)
-    q_eh_dim = q_eh * np.sqrt(R_VAR * GRAV * D50**3) # m3/s
-    # Dimensionful transport capacity [m3/s]
-    tr_cap = q_eh_dim * wac
-    
-    return tr_cap
+        # Ensure any missing keys default to np.nan for consistent output
+        tr_cap = result.get("tr_cap", np.nan)
+        Qc = result.get("Qc", np.nan)
+        
+        return tr_cap, Qc
+        
+        
+# def choose_formula(Fi_r_reach, D50, slope, Q, wac, v, h, psi, indx_tr_cap): 
+#     """
+#     Chooses the transport capacity function based on the given index (indx_tr_cap).
+#     """
+#     # EB D50 entries change according to formula index - it would be good to create a class 
+#     # to call with the string name of the formula 
+#
+#     tau = np.nan
+#     taur50 = np.nan
+#     Qc = np.nan
+#
+#     #choose transport capacity formula
+#     if indx_tr_cap == 1:
+#         tr_cap = Parker_Klingeman_formula(Fi_r_reach, D50, slope, wac, h, psi)
+#
+#     elif indx_tr_cap == 2:
+#         tr_cap =  Wilcock_Crowe_formula(Fi_r_reach, D50, slope, wac, h, psi)
+#
+#     elif indx_tr_cap == 3: 
+#         tr_cap = Engelund_Hansen_formula(D50, slope, wac, v, h)
+#
+#     elif indx_tr_cap == 4: 
+#         tr_cap = Yang_formula(Fi_r_reach, D50, slope, Q, v, h, psi) 
+#
+#     elif indx_tr_cap == 5: 
+#         tr_cap = Wong_Parker_formula(D50, slope, wac, h)
+#
+#     elif indx_tr_cap == 6: 
+#         tr_cap = Ackers_White_formula(D50, slope, Q, v, h)        
+#
+#     elif indx_tr_cap == 7:
+#         tr_cap, Qc = Rickenmann_formula(D50, slope, Q, wac)
+#
+#     return tr_cap, Qc
 
-def Yang_formula(fi_r_reach, D50, slope, Q, v, h, psi): 
-    """
-    Returns the value of the transport capacity [m3/s] for each sediment class
-    in the reach measured using the Yang equations.
-    This function is for use in the D-CASCADE toolbox.
+    def Parker_Klingeman_formula(self):
+        """
+        Returns the value of the transport capacity [Kg/s] for each sediment class
+        in the reach measured using the Parker and Klingeman equations.
+        This function is for use in the D-CASCADE toolbox.
+        CHECK THE UNIT OF THE RETURNED VARIABLE.
+        
+        References:
+        Parker and Klingeman (1982). On why gravel bed streams are paved. Water Resources Research.
+        """
+        
+        #if 'gamma' not in kwargs: # if gamma was not given as input
+        #    gamma = 0.05 # hiding factor
+        
+        dmi = 2**(-self.psi) / 1000 # sediment classes diameter [m]
+        
+        ## Transport capacity from Parker and Klingema equations
+        
+        tau = RHO_W * GRAV * self.h * self.slope # bed shear stress [Kg m-1 s-1]
+        
+        # tau_r50 formula from Mueller et al. (2005)
+        # reference shear stress for the mean size of the bed surface sediment [Kg m-1 s-1]
+        tau_r50 = (0.021 + 2.18 * self.slope) * (RHO_W * R_VAR * GRAV * self.D50)
+        
+        tau_ri = tau_r50 * (dmi/self.D50)** self.gamma # reference shear stress for each sediment class [Kg m-1 s-1]
+        phi_ri = tau / tau_ri
+        
+        # Dimensionless transport rate for each sediment class [-]
+        w_i = 11.2 * (np.maximum(1 - 0.853/phi_ri, 0))**4.5
+        
+        # Dimensionful transport rate for each sediment class [m3/s]
+        tr_cap = self.wac * w_i * self.fi_r_reach * (tau / RHO_W)**(3/2) / (R_VAR * GRAV)
+        tr_cap[np.isnan(tr_cap)] = 0 #if Qbi_tr are NaN, they are put to 0
+        
+        return {"tr_cap": tr_cap}
+        
+    def Wilcock_Crowe_formula(self): 
+        """
+        Returns the value of the transport capacity [m3/s] for each sediment class
+        in the reach measured using the Wilcock and Crowe equations.
+        This function is for use in the D-CASCADE toolbox.
+        
+        References:
+        Wilcock, Crowe(2003). Surface-based transport model for mixed-size sediment. Journal of Hydraulic Engineering.
+        """
     
-    References: 
-    Stevens Jr., H. H. & Yang, C. T. Summary and use of selected fluvial sediment-discharge formulas. (1989).
-    see also: Modern Water Resources Engineering: https://books.google.com/books?id=9rW9BAAAQBAJ&pg
-    =PA347&dq=yang+sediment+transport+1973&hl=de&sa=X&ved=0ahUKEwiYtKr72_bXAhVH2mMKHZwsCdQQ6AEILTAB
-    #v=onepage&q=yang%20sediment%20transport%201973&f=false
-    """
-
-    dmi = 2**(-psi) / 1000 # sediment classes diameter [m]
-    nu = 1.003*1E-6        # kinematic viscosity @ : http://onlinelibrary.wiley.com/doi/10.1002/9781118131473.app3/pdf
+        dmi = 2**(-self.psi) / 1000 # sediment classes diameter [m]
+        
+        if self.fi_r_reach.ndim == 1:
+            self.fi_r_reach = self.fi_r_reach[:,None]
+            # Fraction of sand in river bed (sand considered as sediment with phi > -1)
+            Fr_s = np.sum((self.psi > - 1)[:,None] * 1 * self.fi_r_reach)
+        else:
+            Fr_s = np.sum((self.psi > - 1)[:,None] * 1 * self.fi_r_reach, axis = 0)[None,:]
+        ## Transport capacity from Wilcock-Crowe equations
     
-    GeoStd = GSD_std(fi_r_reach, dmi);
+        tau = np.array(RHO_W * GRAV * self.h * self.slope) # bed shear stress [Kg m-1 s-1]
+        if tau.ndim != 0:
+            tau = tau[None,:] # add a dimension for computation
+        
+        # reference shear stress for the mean size of the bed surface sediment [Kg m-1 s-1]
+        tau_r50 = (0.021 + 0.015 * np.exp(-20 * Fr_s)) * (RHO_W * R_VAR * GRAV * self.D50)
+        
+        b = 0.67 / (1 + np.exp(1.5 - dmi / self.D50)) # hiding factor
+        
+        fact = (dmi / self.D50)**b
+        tau_ri = tau_r50 * fact[:,None] # reference shear stress for each sediment class [Kg m-1 s-1]
+        
+        phi_ri = tau / tau_ri
+        # Dimensionless transport rate for each sediment class [-]
+        # The formula changes for each class according to the phi_ri of the class
+        # is higher or lower then 1.35.
+        W_i = (phi_ri >= 1.35) * (14 * (np.maximum(1 - 0.894 / np.sqrt(phi_ri), 0))**4.5) + (phi_ri < 1.35) * (0.002 * phi_ri**7.5)
+        
+        # Dimensionful transport rate for each sediment class [m3/s]
+        if self.wac.ndim == 0:
+            tr_cap = self.wac * W_i * self.fi_r_reach * (tau / RHO_W)**(3/2) / (R_VAR * GRAV)
+            if tr_cap.ndim > 1:
+               tr_cap = np.squeeze(tr_cap) # EB: a bit of a mess here with dimensions, corrected a posteriori. I want a 1-d vector as output 
+        else:
+            self.wac = np.array(self.wac)[None, :]
+            tr_cap = self.wac * W_i * self.fi_r_reach * (tau / RHO_W)**(3/2) / (R_VAR * GRAV)
+        
+        tr_cap[np.isnan(tr_cap)] = 0 #if Qbi_tr are NaN, they are put to 0
     
-    #  1) settling velocity for grains - Darby, S; Shafaie, A. Fall Velocity of Sediment Particles. (1933)
-    #         
-    #  Dgr = D50*(GRAV*R_VAR/nu**2)**(1/3);
-    #     
-    #  if Dgr<=10:  
-    #      w = 0.51*nu/D50*(D50**3*GRAV*R_VAR/nu**2)**0.963 # EQ. 4: http://www.wseas.us/e-library/conferences/2009/cambridge/WHH/WHH06.pdf
-    #  else:
-    #      w = 0.51*nu/D50*(D50**3*GRAV*R_VAR/nu**2)**0.553 # EQ. 4: http://www.wseas.us/e-library/conferences/2009/cambridge/WHH/WHH06.pdf 
+        return {"tr_cap": tr_cap}
     
-    #2)  settling velocity for grains - Rubey (1933)
-    F = (2 / 3 + 36 * nu**2 / (GRAV * D50**3 * R_VAR))**0.5 - (36 * nu**2/(GRAV * D50**3 * R_VAR))**0.5
-    w = F * (D50 * GRAV * R_VAR)**0.5 #settling velocity
+    def Engelund_Hansen_formula(self):
+        """
+        Returns the value of the transport capacity [m3/s] for each sediment class
+        in the reach measured using the Engelund and Hansen equations.
+        This function is for use in the D-CASCADE toolbox.
+        
+        WARNING: Engelund and Hansen use a factor of 0.1 and but this function uses
+        a factor of 0.05.
+        
+        slope: All reaches' slopes
+        h: All reaches' water heights
+        
+        References:
+        Engelund, F., and E. Hansen (1967), A Monograph on Sediment Transport in 
+        Alluvial Streams, Tekniskforlag, Copenhagen.
+        """
+        
+        # Friction factor (Eq. 3.1.3 of the monograph)
+        C = (2 * GRAV * self.slope * self.h) / self.v**2
     
-    # use corrected sediment diameter
-    tau = 1000 * GRAV * h * slope
-    vstar = np.sqrt(tau / 1000)
-    w50 = (16.17 * D50**2)/(1.8 * 10**(-5) + (12.1275 * D50**3)**0.5)
+        # Dimensionless shear stress (Eq. 3.2.3)
+        tau_eh = (self.slope * self.h) / (R_VAR * self.D50)
+        # Dimensionless transport capacity (Eq. 4.3.5), although Engelund and Hansen
+        # find a factor of 0.1 and not 0.05.
+        q_eh = 0.05 / C * tau_eh**(5/2)
+        # Dimensionful transport capacity per unit width [m3/(s*m)]
+        # (page 56 of the monograph)
+        q_eh_dim = q_eh * np.sqrt(R_VAR * GRAV * self.D50**3) # m3/s
+        # Dimensionful transport capacity [m3/s]
+        tr_cap = q_eh_dim * self.wac
+        
+        return {"tr_cap": tr_cap}
     
-    De = (1.8 * D50) / (1 + 0.8 * (vstar / w50)**0.1 * (GeoStd - 1)**2.2)
+    def Yang_formula(fi_r_reach, D50, slope, Q, v, h, psi): 
+        """
+        Returns the value of the transport capacity [m3/s] for each sediment class
+        in the reach measured using the Yang equations.
+        This function is for use in the D-CASCADE toolbox.
+        
+        References: 
+        Stevens Jr., H. H. & Yang, C. T. Summary and use of selected fluvial sediment-discharge formulas. (1989).
+        see also: Modern Water Resources Engineering: https://books.google.com/books?id=9rW9BAAAQBAJ&pg
+        =PA347&dq=yang+sediment+transport+1973&hl=de&sa=X&ved=0ahUKEwiYtKr72_bXAhVH2mMKHZwsCdQQ6AEILTAB
+        #v=onepage&q=yang%20sediment%20transport%201973&f=false
+        """
     
-    U_star = np.sqrt(De * GRAV * slope) # shear velocity 
+        dmi = 2**(-psi) / 1000 # sediment classes diameter [m]
+        nu = 1.003*1E-6        # kinematic viscosity @ : http://onlinelibrary.wiley.com/doi/10.1002/9781118131473.app3/pdf
+        
+        GeoStd = GSD_std(fi_r_reach, dmi);
+        
+        #  1) settling velocity for grains - Darby, S; Shafaie, A. Fall Velocity of Sediment Particles. (1933)
+        #         
+        #  Dgr = D50*(GRAV*R_VAR/nu**2)**(1/3);
+        #     
+        #  if Dgr<=10:  
+        #      w = 0.51*nu/D50*(D50**3*GRAV*R_VAR/nu**2)**0.963 # EQ. 4: http://www.wseas.us/e-library/conferences/2009/cambridge/WHH/WHH06.pdf
+        #  else:
+        #      w = 0.51*nu/D50*(D50**3*GRAV*R_VAR/nu**2)**0.553 # EQ. 4: http://www.wseas.us/e-library/conferences/2009/cambridge/WHH/WHH06.pdf 
+        
+        #2)  settling velocity for grains - Rubey (1933)
+        F = (2 / 3 + 36 * nu**2 / (GRAV * D50**3 * R_VAR))**0.5 - (36 * nu**2/(GRAV * D50**3 * R_VAR))**0.5
+        w = F * (D50 * GRAV * R_VAR)**0.5 #settling velocity
+        
+        # use corrected sediment diameter
+        tau = 1000 * GRAV * h * slope
+        vstar = np.sqrt(tau / 1000)
+        w50 = (16.17 * D50**2)/(1.8 * 10**(-5) + (12.1275 * D50**3)**0.5)
+        
+        De = (1.8 * D50) / (1 + 0.8 * (vstar / w50)**0.1 * (GeoStd - 1)**2.2)
+        
+        U_star = np.sqrt(De * GRAV * slope) # shear velocity 
+        
+        # 1) Yang Sand Formula
+        log_C = 5.165 - 0.153 * np.log10(w * De / nu) - 0.297 * np.log10(U_star / w) + (1.78 - 0.36 * np.log10(w * De / nu) - 0.48 * np.log10(U_star / w)) * np.log10(v * slope / w) 
+        
+        # 2) Yang Gravel Formula
+        #log_C = 6.681 - 0.633*np.log10(w*D50/nu) - 4.816*np.log10(U_star/w) + (2.784-0.305*np.log10(w*D50/nu)-0.282*np.log10(U_star/w))*np.log10(v*slope/w) 
+       
+        QS_ppm = 10**(log_C) # in ppm 
+        
+        QS_grams = QS_ppm # in g/m3
+        QS_grams_per_sec = QS_grams * Q # in g/s
+        QS_kg = QS_grams_per_sec / 1000 # in kg/s
+        
+        QS_Yang = QS_kg / RHO_S # m3/s
+        
+        tr_cap = QS_Yang
+        
+        return {"tr_cap": tr_cap}
     
-    # 1) Yang Sand Formula
-    log_C = 5.165 - 0.153 * np.log10(w * De / nu) - 0.297 * np.log10(U_star / w) + (1.78 - 0.36 * np.log10(w * De / nu) - 0.48 * np.log10(U_star / w)) * np.log10(v * slope / w) 
+    def Ackers_White_formula(D50, slope, Q, v, h):
+        """
+        Returns the value of the transport capacity [m3/s] for each sediment class
+        in the reach measured using the Ackers and White equations.
+        This function is for use in the D-CASCADE toolbox.
+        
+        References:
+        Stevens Jr., H. H. & Yang, C.T. Summary and use of selected fluvial sediment-discharge formulas. (1989).
+        Ackers P., White W.R. Sediment transport: New approach and analysis (1973)
+        """
+        
+        #FR = v/np.sqrt(g*h)     #Froude number
+        
+        # Ackers - White suggest to use the D35 instead of the D50
+        D_AW = D50
+        
+        nu = 1.003*1E-6 # kinematic viscosity @ 20�C: http://onlinelibrary.wiley.com/doi/10.1002/9781118131473.app3/pdf
+        #nu = 0.000011337  # kinematic viscosity (ft2/s)
+        
+        alpha = 10 # coefficient in the rough turbulent equation with a value of 10;
+        
+        #conv = 0.3048 #conversion 1 feet to meter
+        
+        ## transition exponent depending on sediment size [n]
+        
+        D_gr = D_AW * (GRAV * R_VAR / nu**2)**(1/3) #dimensionless grain size - EB change coding line if D_gr is different from a number 
+        
+        #shear velocity
+        u_ast = np.sqrt(GRAV * h * slope)
+        
+        ## Transport capacity 
+        
+        #coefficient for dimensionless transport calculation
+        C = 0.025
+        m = 1.50    # m = 1.78
+        A = 0.17
+        n = 0
+        
+        C = np.matlib.repmat(C, 1, 1) #np.matlib.repmat(m, D_gr.shape[0],D_gr.shape[1])
+        m = np.matlib.repmat(m, 1, 1) #np.matlib.repmat(m, D_gr.shape[0],D_gr.shape[1])
+        A = np.matlib.repmat(A, 1, 1) #np.matlib.repmat(m, D_gr.shape[0],D_gr.shape[1])
+        n = np.matlib.repmat(n, 1, 1) #np.matlib.repmat(m, D_gr.shape[0],D_gr.shape[1])
+        
+        if np.less(D_gr, 60).any(): 
+            C[D_gr < 60] = 10 ** (2.79 * np.log10(D_gr[D_gr < 60]) - 0.98 * np.log10(D_gr[D_gr < 60])**2 - 3.46)
+            m[D_gr < 60] = 6.83 / D_gr[D_gr < 60] + 1.67     # m = 9.66 / D_gr(D_gr < 60) + 1.34;
+            A[D_gr < 60] = 0.23 / np.sqrt(D_gr[D_gr < 60]) + 0.14
+            n[D_gr < 60] = 1 - 0.56 * np.log10(D_gr[D_gr < 60])
+        
+        ## mobility factor
+        F_gr = u_ast**n / np.sqrt(GRAV * D_AW * R_VAR) * (v / (np.sqrt(32) * np.log10(alpha * h / D_AW)))**(1 - n)
+         
+        # dimensionless transport
+        G_gr = C * (np.maximum(F_gr / A - 1, 0) )**m
+        
+        # weight concentration of bed material (Kg_sed / Kg_water)
+        QS_ppm = G_gr * (R_VAR + 1) * D_AW * (v / u_ast)**n / h
+        
+        # transport capacity (Kg_sed / s)
+        QS_kg = RHO_W * Q * QS_ppm
+        
+        # transport capacity [m3/s]
+        QS_AW = QS_kg / RHO_S
+        
+        tr_cap = QS_AW
+        
+        return {"tr_cap": tr_cap}
+    def Wong_Parker_formula(D50, slope, wac, h):
+        """
+        Returns the value of the transport capacity [m3/s] for each sediment class
+        in the reach measured using the Wong-Parker equations. 
+        This function is for use in the D-CASCADE toolbox.
+        
+        References:
+        Wong, M., and G. Parker (2006), Reanalysis and correction of bed-load relation
+        of Meyer-Peter and M�uller using their own database, J. Hydraul. Eng., 132(11),
+        1159�1168, doi:10.1061/(ASCE)0733-9429(2006)132:11(1159).
+        """
     
-    # 2) Yang Gravel Formula
-    #log_C = 6.681 - 0.633*np.log10(w*D50/nu) - 4.816*np.log10(U_star/w) + (2.784-0.305*np.log10(w*D50/nu)-0.282*np.log10(U_star/w))*np.log10(v*slope/w) 
-   
-    QS_ppm = 10**(log_C) # in ppm 
+        # Wong_Parker parameters 
+        alpha = 3.97   # alpha = 4.93
+        beta = 1.5     # beta = 1.6
+        tauC = 0.0495  # tauC = 0.0470
+        
+        # dimensionless shear stress
+        tauWP = (slope * h) / (R_VAR * D50)
+        # dimensionless transport capacity
+        qWP = alpha* (np.maximum(tauWP - tauC, 0))**beta
+        # dimensionful transport capacity [m3/(s*m)] 
+        qWP_dim = qWP * np.sqrt(R_VAR * GRAV * D50**3) # [m3/(s*m)] (formula from the original cascade paper)
+        
+        QS_WP = qWP_dim * wac # [m3/s]
+        
+        tr_cap = QS_WP # [m3/s]
     
-    QS_grams = QS_ppm # in g/m3
-    QS_grams_per_sec = QS_grams * Q # in g/s
-    QS_kg = QS_grams_per_sec / 1000 # in kg/s
+        return {"tr_cap": tr_cap}
     
-    QS_Yang = QS_kg / RHO_S # m3/s
+    def Rickenmann_formula(D50, slope, Q, wac):
+        """
+        Rickenmann's formula for bedload transport capacity based on unit discharge
+        for slopes of 0.04% - 20%.
+        Critical discharge Qc is based on the equation probosed by Barthust et al. (1987)
+        and later refined by Rickenmann (1991).
+        
+        References: 
+        Rickenmann (2001). Comparison of bed load transport in torrents and gravel bed streams. 
+        Water Resources Research 37(12): 3295–3305.DOI: 10.1029/2001WR000319.
+        Barthust et al. (1987). Bed load discharge equations for steep mountain rivers. 
+        In Sediment Transport in Gravel-Bed Rivers, Wiley: New York; 453–477
+        Rickenmann (1991). Hyperconcentrated flow and sediment transport at steep flow. 
+        Journal ofHydraulic Engineering 117(11): 1419–1439. DOI: 10.1061/(ASCE)0733-9429(1991)117:11(1419)
+        """
+        
+        # Q is on whole width, Qunit = Q/w
+        Qunit = Q / wac
+        
+        exponent_e = 1.5
+        # critical unit discharge
+        Qc = 0.065 * (R_VAR ** 1.67) * (GRAV ** 0.5) * (D50 ** exponent_e) * (slope ** (-1.12))
     
-    tr_cap = QS_Yang
+        #Check if Q is smaller than Qc
+        Qarr = np.full_like(Qc, Qunit)
+        
+        Qb = np.zeros_like(Qc)
+        
+        condition = (Qarr - Qc) < 0
+        Qb = np.where(condition, 0, 1.5 * (Qarr - Qc) * (slope ** 1.5))
     
-    return tr_cap
-
-def Ackers_White_formula(D50, slope, Q, v, h):
-    """
-    Returns the value of the transport capacity [m3/s] for each sediment class
-    in the reach measured using the Ackers and White equations.
-    This function is for use in the D-CASCADE toolbox.
+        Qb_Wac = Qb * wac
+        tr_cap = Qb_Wac
     
-    References:
-    Stevens Jr., H. H. & Yang, C.T. Summary and use of selected fluvial sediment-discharge formulas. (1989).
-    Ackers P., White W.R. Sediment transport: New approach and analysis (1973)
-    """
-    
-    #FR = v/np.sqrt(g*h)     #Froude number
-    
-    # Ackers - White suggest to use the D35 instead of the D50
-    D_AW = D50
-    
-    nu = 1.003*1E-6 # kinematic viscosity @ 20�C: http://onlinelibrary.wiley.com/doi/10.1002/9781118131473.app3/pdf
-    #nu = 0.000011337  # kinematic viscosity (ft2/s)
-    
-    alpha = 10 # coefficient in the rough turbulent equation with a value of 10;
-    
-    #conv = 0.3048 #conversion 1 feet to meter
-    
-    ## transition exponent depending on sediment size [n]
-    
-    D_gr = D_AW * (GRAV * R_VAR / nu**2)**(1/3) #dimensionless grain size - EB change coding line if D_gr is different from a number 
-    
-    #shear velocity
-    u_ast = np.sqrt(GRAV * h * slope)
-    
-    ## Transport capacity 
-    
-    #coefficient for dimensionless transport calculation
-    C = 0.025
-    m = 1.50    # m = 1.78
-    A = 0.17
-    n = 0
-    
-    C = np.matlib.repmat(C, 1, 1) #np.matlib.repmat(m, D_gr.shape[0],D_gr.shape[1])
-    m = np.matlib.repmat(m, 1, 1) #np.matlib.repmat(m, D_gr.shape[0],D_gr.shape[1])
-    A = np.matlib.repmat(A, 1, 1) #np.matlib.repmat(m, D_gr.shape[0],D_gr.shape[1])
-    n = np.matlib.repmat(n, 1, 1) #np.matlib.repmat(m, D_gr.shape[0],D_gr.shape[1])
-    
-    if np.less(D_gr, 60).any(): 
-        C[D_gr < 60] = 10 ** (2.79 * np.log10(D_gr[D_gr < 60]) - 0.98 * np.log10(D_gr[D_gr < 60])**2 - 3.46)
-        m[D_gr < 60] = 6.83 / D_gr[D_gr < 60] + 1.67     # m = 9.66 / D_gr(D_gr < 60) + 1.34;
-        A[D_gr < 60] = 0.23 / np.sqrt(D_gr[D_gr < 60]) + 0.14
-        n[D_gr < 60] = 1 - 0.56 * np.log10(D_gr[D_gr < 60])
-    
-    ## mobility factor
-    F_gr = u_ast**n / np.sqrt(GRAV * D_AW * R_VAR) * (v / (np.sqrt(32) * np.log10(alpha * h / D_AW)))**(1 - n)
-     
-    # dimensionless transport
-    G_gr = C * (np.maximum(F_gr / A - 1, 0) )**m
-    
-    # weight concentration of bed material (Kg_sed / Kg_water)
-    QS_ppm = G_gr * (R_VAR + 1) * D_AW * (v / u_ast)**n / h
-    
-    # transport capacity (Kg_sed / s)
-    QS_kg = RHO_W * Q * QS_ppm
-    
-    # transport capacity [m3/s]
-    QS_AW = QS_kg / RHO_S
-    
-    tr_cap = QS_AW
-    
-    return tr_cap
+        return {"tr_cap": tr_cap, "Qc": Qc}
     
 def GSD_std(Fi_r, dmi):
     """
@@ -290,71 +445,6 @@ def GSD_std(Fi_r, dmi):
     
     return std
     
-def Wong_Parker_formula(D50, slope, wac, h):
-    """
-    Returns the value of the transport capacity [m3/s] for each sediment class
-    in the reach measured using the Wong-Parker equations. 
-    This function is for use in the D-CASCADE toolbox.
-    
-    References:
-    Wong, M., and G. Parker (2006), Reanalysis and correction of bed-load relation
-    of Meyer-Peter and M�uller using their own database, J. Hydraul. Eng., 132(11),
-    1159�1168, doi:10.1061/(ASCE)0733-9429(2006)132:11(1159).
-    """
-
-    # Wong_Parker parameters 
-    alpha = 3.97   # alpha = 4.93
-    beta = 1.5     # beta = 1.6
-    tauC = 0.0495  # tauC = 0.0470
-    
-    # dimensionless shear stress
-    tauWP = (slope * h) / (R_VAR * D50)
-    # dimensionless transport capacity
-    qWP = alpha* (np.maximum(tauWP - tauC, 0))**beta
-    # dimensionful transport capacity [m3/(s*m)] 
-    qWP_dim = qWP * np.sqrt(R_VAR * GRAV * D50**3) # [m3/(s*m)] (formula from the original cascade paper)
-    
-    QS_WP = qWP_dim * wac # [m3/s]
-    
-    tr_cap = QS_WP # [m3/s]
-
-    return tr_cap
-
-def Rickenmann_formula(D50, slope, Q, wac):
-    """
-    Rickenmann's formula for bedload transport capacity based on unit discharge
-    for slopes of 0.04% - 20%.
-    Critical discharge Qc is based on the equation probosed by Barthust et al. (1987)
-    and later refined by Rickenmann (1991).
-    
-    References: 
-    Rickenmann (2001). Comparison of bed load transport in torrents and gravel bed streams. 
-    Water Resources Research 37(12): 3295–3305.DOI: 10.1029/2001WR000319.
-    Barthust et al. (1987). Bed load discharge equations for steep mountain rivers. 
-    In Sediment Transport in Gravel-Bed Rivers, Wiley: New York; 453–477
-    Rickenmann (1991). Hyperconcentrated flow and sediment transport at steep flow. 
-    Journal ofHydraulic Engineering 117(11): 1419–1439. DOI: 10.1061/(ASCE)0733-9429(1991)117:11(1419)
-    """
-    
-    # Q is on whole width, Qunit = Q/w
-    Qunit = Q / wac
-    
-    exponent_e = 1.5
-    # critical unit discharge
-    Qc = 0.065 * (R_VAR ** 1.67) * (GRAV ** 0.5) * (D50 ** exponent_e) * (slope ** (-1.12))
-
-    #Check if Q is smaller than Qc
-    Qarr = np.full_like(Qc, Qunit)
-    
-    Qb = np.zeros_like(Qc)
-    
-    condition = (Qarr - Qc) < 0
-    Qb = np.where(condition, 0, 1.5 * (Qarr - Qc) * (slope ** 1.5))
-
-    Qb_Wac = Qb * wac
-    tr_cap = Qb_Wac
-
-    return tr_cap, Qc
 
 def Molinas_rates(fi_r, h, v, slope, dmi_finer, D50_finer):
     """
@@ -395,44 +485,7 @@ def Molinas_rates(fi_r, h, v, slope, dmi_finer, D50_finer):
     frac1 = fi_r * ((dmi_finer / Dn)**alpha + zeta * (dmi_finer / Dn)**beta) # Nominator in EQ 23, Molinas and Wu (2000) 
     pci = frac1 / np.sum(frac1)
         
-    return pci  
-
-
-def choose_formula(Fi_r_reach, D50, slope, Q, wac, v, h, psi, indx_tr_cap): 
-    """
-    Chooses the transport capacity function based on the given index (indx_tr_cap).
-    """
-    # EB D50 entries change according to formula index - it would be good to create a class 
-    # to call with the string name of the formula 
-
-    tau = np.nan
-    taur50 = np.nan
-    Qc = np.nan
- 
-    #choose transport capacity formula
-    if indx_tr_cap == 1:
-        [tr_cap, tau, taur50] = Parker_Klingeman_formula(Fi_r_reach, D50, slope, wac, h, psi)
-    
-    elif indx_tr_cap == 2:
-        [tr_cap, tau, taur50] =  Wilcock_Crowe_formula(Fi_r_reach, D50, slope, wac, h, psi)
-    
-    elif indx_tr_cap == 3: 
-        tr_cap = Engelund_Hansen_formula(D50, slope, wac, v, h)
-    
-    elif indx_tr_cap == 4: 
-        tr_cap = Yang_formula(Fi_r_reach, D50, slope, Q, v, h, psi) 
-    
-    elif indx_tr_cap == 5: 
-        tr_cap = Wong_Parker_formula(D50, slope, wac, h)
-    
-    elif indx_tr_cap == 6: 
-        tr_cap = Ackers_White_formula(D50, slope, Q, v, h)        
-    
-    elif indx_tr_cap == 7:
-        tr_cap, Qc = Rickenmann_formula(D50, slope, Q, wac)
-    
-    return tr_cap, Qc
-
+    return pci
 
 
 def tr_cap_function(Fi_r_reach, D50, slope, Q, wac, v, h, psi, indx_tr_cap, indx_partition):
@@ -451,23 +504,25 @@ def tr_cap_function(Fi_r_reach, D50, slope, Q, wac, v, h, psi, indx_tr_cap, indx
 
     Qtr_cap = np.zeros(len(psi))[None]
     
+    calculator = TransportCapacityCalculator(Fi_r_reach, D50, slope, Q, wac, v, h, psi)
+    
     if indx_partition == 1: # Direct computation by the size fraction approach  
         
-        Qtr_cap,Qc = choose_formula(Fi_r_reach, dmi, slope, Q, wac, v, h, psi, indx_tr_cap)
+        Qtr_cap,Qc = calculator.choose_formula(indx_tr_cap)
         pci = Fi_r_reach
         
     elif indx_partition == 2: # The BMF approach (Bed Material Fraction)
-        tr_cap, Qc =  choose_formula(Fi_r_reach, dmi, slope, Q, wac, v, h, psi, indx_tr_cap)
+        tr_cap, Qc = calculator.choose_formula(indx_tr_cap)
         Qtr_cap = Fi_r_reach*tr_cap
         pci = Fi_r_reach 
         
     elif indx_partition == 3: # The TCF approach (Transport Capacity Fraction) with the Molinas formula (Molinas and Wu, 2000)
         pci = Molinas_rates(Fi_r_reach, h, v, slope, dmi*1000, D50*1000)
-        tr_cap, Qc = choose_formula(Fi_r_reach, D50, slope, Q, wac, v, h, psi, indx_tr_cap)
+        tr_cap, Qc = calculator.choose_formula(indx_tr_cap)
         Qtr_cap = pci * tr_cap
     
     elif indx_partition == 4: #Shear stress correction approach (for fractional transport formulas)
-        tr_cap, Qc = choose_formula(Fi_r_reach, D50, slope, Q, wac, v, h, psi, indx_tr_cap)
+        tr_cap, Qc = calculator.choose_formula(indx_tr_cap)
         Qtr_cap = tr_cap #these formulas returns already partitioned results;
         pci = Qtr_cap / np.sum(Qtr_cap)
       

--- a/transport_capacity_computation.py
+++ b/transport_capacity_computation.py
@@ -224,6 +224,9 @@ class TransportCapacityCalculator:
         q_eh_dim = q_eh * np.sqrt(R_VAR * GRAV * self.D50**3) # m3/s
         # Dimensionful transport capacity [m3/s]
         tr_cap = q_eh_dim * self.wac
+        print(C, tau_eh, q_eh, q_eh_dim)
+        print(tr_cap)
+        print(bjo)
         
         return {"tr_cap": tr_cap}
     

--- a/unitary_tests_Po_case.py
+++ b/unitary_tests_Po_case.py
@@ -11,7 +11,7 @@ from preprocessing import graph_preprocessing, extract_Q
 from pathlib import Path
 import geopandas as gpd
 from GSD import GSDcurvefit
-
+import time
 
 
 
@@ -387,11 +387,13 @@ def test_Po_Engelund_all_new_options_true():
                             # (= arriving cascade + possibly reach material)   
     indx_vel_partition = 1  # same velocity for all classes
                
-
     # Run definition
+    start = time.time()
     data_output, extended_output = DCASCADE_main(indx_tr_cap , indx_tr_partition, indx_velocity, indx_vel_partition,
                                                  reach_data, Network, Q, Qbi_input, Qbi_dep_in, timescale, psi,
                                                  roundpar, update_slope, eros_max, save_dep_layer, ts_length)
+    end = time.time()
+    print(end - start)
         
     # Test the total mobilised volume per reach
     test_result = np.sum(data_output['Mobilized [m^3]'], axis = 0)


### PR DESCRIPTION
Created a TransportCapacityCalculator class (TCC class). 

- Vjosa and Po tests are working, but **not yet the transport tests** since they now require an object to be created first.
- The D50/dmi definitions in the different formula remains unclear, especially due to the way the different partitioning methods feeds them to the TransportCapacityCalculator class. **This needs to be defined more clearly...**
- **The partitioning should be included in the TCC class** once understood. 
- The TCC class **could link to a SedimentarySystem object** (once such a class is created) to avoid defining such a high number of own attributes.